### PR TITLE
Test value of build URLs in both preview and production

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -7,8 +7,8 @@
     <!-- Use title if it's in the page YAML frontmatter -->
     <title><%= page_title %></title>
 
-    <!-- DEPLOY_PRIME_URL: <%= ENV["DEPLOY_PRIME_URL"] %> -->
-    <!-- URL: <%= ENV["URL"] %> -->
+    <!-- DEPLOY_PRIME_URL: <%= ENV["DEPLOY_PRIME_URL"].inspect %> -->
+    <!-- URL: <%= ENV["URL"].inspect %> -->
 
     <%= stylesheet_link_tag "all" %>
 

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -7,6 +7,9 @@
     <!-- Use title if it's in the page YAML frontmatter -->
     <title><%= page_title %></title>
 
+    <!-- DEPLOY_PRIME_URL: <%= ENV["DEPLOY_PRIME_URL"] %> -->
+    <!-- URL: <%= ENV["URL"] %> -->
+
     <%= stylesheet_link_tag "all" %>
 
     <link rel="alternate" type="application/rss+xml" title="Podcast RSS Feed" href="<%= full_url("/episodes.rss") %>" />


### PR DESCRIPTION
I'm pretty sure DEPLOY_PRIME_URL will be the actual configured domain (same as URL) in production (and likely won't be the same in a deploy preview, since docs suggest URL should always be the production URL), but want to verify that so I don't break the RSS feed if I rely on that.
